### PR TITLE
docs: Update codecov and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![CI](https://github.com/seafloor-geodesy/gnatss/actions/workflows/ci.yaml/badge.svg)](https://github.com/seafloor-geodesy/gnatss/actions/workflows/ci.yaml)
 [![Documentation Status](https://readthedocs.org/projects/gnatss/badge/?version=latest)](https://gnatss.readthedocs.io/en/latest/?badge=latest)
-[![codecov](https://codecov.io/gh/uw-ssec/offshore-geodesy/branch/main/graph/badge.svg?token=Z5L0RYOVEZ)](https://codecov.io/gh/uw-ssec/offshore-geodesy)
+[![codecov](https://codecov.io/gh/seafloor-geodesy/gnatss/graph/badge.svg?token=XB7S8FYOG7)](https://codecov.io/gh/seafloor-geodesy/gnatss)
 <br>
 [![Hatch project](https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg)](https://github.com/pypa/hatch)
 [![code style - Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
@@ -13,19 +13,16 @@
 
 GNATSS is an open-source software for processing Global Navigation Satellite Systems - Acoustic (GNSS-A) data for seafloor horizontal positioning.
 The software is a redevelopment of existing FORTRAN codes and shell scripts developed by C. David Chadwell for processing data including measurements made with Wave Gliders.
-Existing code, which includes proprietary routines, is developed and maintained by John DeSanto,
-which can be found at [johnbdesanto/SeafloorGeodesy](https://github.com/johnbdesanto/SeafloorGeodesy).
-
-Notion page for project can be found [here](https://safe-mouse-a43.notion.site/GNSS-Acoustic-01f0423b3e2146f6a4465211f29cd9b9).
+Existing code, which includes proprietary routines, is developed and maintained by [John DeSanto](https://github.com/johnbdesanto).
 
 ## Using the software
 
 **This software is currently under heavy development and is not available via [PyPI](https://pypi.org/), the Python Package Index**
 
-You can install the software with pip directly from the main branch of the repo by running the following command:
+You can install the software with pip directly by running the following command:
 
 ```bash
-pip install git+https://github.com/uw-ssec/offshore-geodesy@main
+pip install gnatss
 ```
 
 Once the software is installed, you should be able to get to the GNATSS Command Line Interface (CLI)
@@ -166,7 +163,7 @@ Please refer to our [Contributing Guide](.github/CONTRIBUTING.md) on how to setu
 
 Thanks to our contributors so far!
 
-[![Contributors](https://contrib.rocks/image?repo=uw-ssec/offshore-geodesy)](https://github.com/uw-ssec/offshore-geodesy/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=seafloor-geodesy/gnatss)](https://github.com/seafloor-geodesy/gnatss/graphs/contributors)
 
 ## Open source licensing
 


### PR DESCRIPTION
Update the codecov links and other links that point to uw-ssec to the current organization.