### PR TITLE
docs: Add a small section about the benchmarking

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -11,6 +11,14 @@ in regions responsible for some of the largest earthquakes and tsunamis ever rec
 
 Check out the [Seafloor Geodesy](https://www.seafloorgeodesy.org/) website for more information about the community project.
 
+## GNATSS - Fortran Benchmark
+
+We've created a simple Jupyter Notebook to benchmark GNATSS results against Chadwell's Fortran code results.
+The repository for this benchmarking can be found in the Seafloor Geodesy Github Organization repository called
+[gnatss-fortran-benchmark](https://github.com/seafloor-geodesy/gnatss-fortran-benchmark).
+The rendered version of the main notebook can also be viewed
+[here](https://nbviewer.org/github/seafloor-geodesy/gnatss-fortran-benchmark/blob/main/main.ipynb).
+
 ## Table of contents
 
 ```{tableofcontents}


### PR DESCRIPTION
Add a small section in the main intro page of the documentation page about the benchmarking repository and main jupyter notebook.