### PR TITLE
refactor: Update run flags for distance center, process dataset, and qc

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,18 @@ You can retrieve the helper text for this command by running `gnatss run --help`
 │                                                                   yaml file. **Currently only  │
 │                                                                   support local files!**       │
 │                                                                   [default: None]              │
-│ --extract-dist-center        --no-extract-dist-center             Flag to extract distance     │
+│ --extract-dist-center         --no-extract-dist-center            Flag to extract distance     │
 │                                                                   from center from run.        │
 │                                                                   [default:                    │
-│                                                                   no-extract-dist-center]      │
-│ --extract-process-dataset    --no-extract-process-data…           Flag to extract process      │
+│                                                                   extract-dist-center]         │
+│ --extract-process-dataset     --no-extract-process-data           Flag to extract process      │
 │                                                                   results.                     │
 │                                                                   [default:                    │
-│                                                                   no-extract-process-dataset]  │
+│                                                                   extract-process-dataset]     │
+│ --qc                          --no-qc                             Flag to plot residuals from  │
+│                                                                   run and store in             │
+│                                                                   output folder.               │
+│                                                                   [default: qc]                │
 │ --distance-limit                                           FLOAT  Distance in meters from      │
 │                                                                   center beyond which points   │
 │                                                                   will be excluded from        │

--- a/src/gnatss/cli.py
+++ b/src/gnatss/cli.py
@@ -30,10 +30,10 @@ def run(
         help="Custom path to configuration yaml file. **Currently only support local files!**",
     ),
     extract_dist_center: Optional[bool] = typer.Option(
-        False, help="Flag to extract distance from center from run."
+        True, help="Flag to extract distance from center from run."
     ),
     extract_process_dataset: Optional[bool] = typer.Option(
-        False, help="Flag to extract process results."
+        True, help="Flag to extract process results."
     ),
     outlier_threshold: Optional[float] = typer.Option(
         constants.DATA_OUTLIER_THRESHOLD,
@@ -57,7 +57,7 @@ def run(
         ),
     ),
     qc: Optional[bool] = typer.Option(
-        False, help="Flag to plot residuals from run and store in output folder."
+        True, help="Flag to plot residuals from run and store in output folder."
     ),
 ) -> None:
     """Runs the full pre-processing routine for GNSS-A


### PR DESCRIPTION
* Linked to Issue #208
* Make extract-dist-center, extract-process-dataset, and qc CLI arguments default to True