### PR TITLE
fix: Fixed the ignoring of 'parsed' files

### DIFF
--- a/src/gnatss/loaders.py
+++ b/src/gnatss/loaders.py
@@ -122,7 +122,6 @@ def load_travel_times(
     Additionally, there's an assumption that wave glider delays
     have been removed from the data.
     """
-    PARSED_FILE = "parsed"
     DATETIME_FORMAT = "%d-%b-%y %H:%M:%S.%f"
 
     columns = [constants.TT_DATE, constants.TT_TIME, *transponder_ids]
@@ -130,11 +129,7 @@ def load_travel_times(
         # If it's already j2k then pop off date column, idx 0
         columns.pop(0)
     # Read all travel times
-    travel_times = [
-        pd.read_csv(i, delim_whitespace=True, header=None)
-        for i in files
-        if PARSED_FILE not in i
-    ]
+    travel_times = [pd.read_csv(i, delim_whitespace=True, header=None) for i in files]
     all_travel_times = pd.concat(travel_times).reset_index(drop=True)
 
     # Remove any columns that are not being used

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -29,8 +29,6 @@ from gnatss.loaders import (
 from gnatss.main import gather_files
 from tests import TEST_DATA_FOLDER
 
-PARSED_FILE = "parsed"
-
 
 @pytest.fixture
 def configuration() -> Dict[str, Any]:
@@ -97,11 +95,7 @@ def _load_travel_times_pass_testcase_helper(
 
     # raw_travel_times contains the expected df
     raw_travel_times = concat(
-        [
-            read_csv(i, delim_whitespace=True, header=None)
-            for i in travel_times
-            if PARSED_FILE not in i
-        ]
+        [read_csv(i, delim_whitespace=True, header=None) for i in travel_times]
     ).reset_index(drop=True)
 
     column_num_diff = len(expected_columns) - len(raw_travel_times.columns)


### PR DESCRIPTION
Removed the exception to ignore 'parsed' files
since now users can separate these files in a separate directory instead and specify that in the config yaml.

---
Ref: https://github.com/seafloor-geodesy/gnatss/issues/214