### PR TITLE
(build): Need a config to ignore test data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include LICENSE
-include README.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,3 +88,8 @@ version-file = "src/gnatss/version.py"
 
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/tests",
+]


### PR DESCRIPTION
* MANIFEST.in file is used only when using the setuptools build system. However as mentioned in the pyproject.toml we are using hatchling build system instead. We can therefore remove this MANIFEST file.
* Exclude the ./tests directory from the build step. the source distribution file reduced in size significantly. This speeds up gnatss pip installation speed due to faster downloading, and lesser unzipping.
* Solves Issue #220 