### PR TITLE
feat(posfilter): roll-pitch-heading loader function should accept optional covariance rows

### DIFF
--- a/src/gnatss/cli.py
+++ b/src/gnatss/cli.py
@@ -8,7 +8,7 @@ from . import constants, package_name
 from .configs.io import CSVOutput
 from .configs.solver import Solver
 from .loaders import load_configuration
-from .main import gather_files, main
+from .main import gather_files_all_procs, main
 
 # Global variables
 OVERRIDE_MESSAGE = "Note that this will override the value set as configuration."
@@ -76,10 +76,7 @@ def run(
         config.solver.residual_limit = residual_limit
 
     typer.echo("Configuration loaded.")
-    all_files_dict = dict()
-    for proc in ("solver", "posfilter"):
-        if getattr(config, proc):
-            all_files_dict.update(gather_files(config, proc))
+    all_files_dict = gather_files_all_procs(config)
 
     # Run the main function
     # TODO: Clean up so that we aren't throwing data away

--- a/src/gnatss/constants/__init__.py
+++ b/src/gnatss/constants/__init__.py
@@ -6,6 +6,9 @@ from . import garpos
 
 __all__ = ["garpos"]
 
+# Config constants
+DEFAULT_CONFIG_PROCS = ("solver", "posfilter")
+
 # General constants
 SIG_3D = "sig_3d"
 DELAY_TIME_PRECISION = 6
@@ -77,7 +80,28 @@ RPH_TIME = TIME_J2000
 RPH_ROLL = "roll"
 RPH_PITCH = "pitch"
 RPH_HEADING = "heading"
-RPH_COLUMNS = [RPH_ROLL, RPH_PITCH, RPH_HEADING]
+RPH_LOCAL_TANGENTS = [RPH_ROLL, RPH_PITCH, RPH_HEADING]
+RPH_COV_RR = "roll_roll"
+RPH_COV_RP = "roll_pitch"
+RPH_COV_RH = "roll_heading"
+RPH_COV_PR = "pitch_roll"
+RPH_COV_PP = "pitch_pitch"
+RPH_COV_PH = "pitch_heading"
+RPH_COV_HR = "heading_roll"
+RPH_COV_HP = "heading_pitch"
+RPH_COV_HH = "heading_heading"
+RPH_COV_DIAG = [RPH_COV_RR, RPH_COV_PP, RPH_COV_HH]  # Covariance matrix diagonal values
+RPH_COV = [
+    RPH_COV_RR,
+    RPH_COV_RP,
+    RPH_COV_RH,
+    RPH_COV_PR,
+    RPH_COV_PP,
+    RPH_COV_PH,
+    RPH_COV_HR,
+    RPH_COV_HP,
+    RPH_COV_HH,
+]  # Covariance matrix columns
 
 # Antenna Position Direction columns
 ANTENNA_EASTWARD = "ant_e"

--- a/src/gnatss/loaders.py
+++ b/src/gnatss/loaders.py
@@ -186,24 +186,33 @@ def load_roll_pitch_heading(files: List[str]) -> pd.DataFrame:
     pd.DataFrame
         Pandas DataFrame containing all of the roll pitch heading data.
         Expected columns will have 'time' and the 'roll', 'pitch', 'heading' values.
+        Optional roll, pitch, heading covariance columns will be dropped from the dataframe.
         Return empty Dataframe if files is empty string.
     """
-    columns = [
+    required_columns = [
         constants.RPH_TIME,
-        *constants.RPH_COLUMNS,
+        *constants.RPH_LOCAL_TANGENTS,
     ]
+    optional_columns = [*constants.RPH_COV]
+
     if files:
         # Read all rph files
         rph_dfs = [
-            pd.read_csv(i, delim_whitespace=True, header=None, names=columns)
+            pd.read_csv(
+                i,
+                delim_whitespace=True,
+                header=None,
+                names=[*required_columns, *optional_columns],
+            )
             .drop_duplicates(constants.RPH_TIME)
             .reset_index(drop=True)
             for i in files
         ]
-        all_rph = pd.concat(rph_dfs).reset_index(drop=True)
+        # Remove optional columns from all_rph df
+        all_rph = pd.concat(rph_dfs)[required_columns].reset_index(drop=True)
         return all_rph
     else:
-        return pd.DataFrame(columns=columns)
+        return pd.DataFrame(columns=required_columns)
 
 
 def get_atd_offsets(config: Configuration) -> Union[NDArray[Shape["3"], Float], None]:

--- a/src/gnatss/main.py
+++ b/src/gnatss/main.py
@@ -34,12 +34,14 @@ from .utilities.time import AstroTime
 def gather_files(
     config: Configuration, proc: Literal["solver", "posfilter"] = "solver"
 ) -> Dict[str, List[str]]:
-    """Gather file paths for the various dataset files
+    """Gather file paths for the various dataset files defined in proc config.
 
     Parameters
     ----------
     config : Configuration
         A configuration object
+    proc: Literal["solver", "posfilter"]
+        Process name as defined in config
 
     Returns
     -------
@@ -65,6 +67,26 @@ def gather_files(
                 all_files = [path]
 
             all_files_dict.setdefault(k, all_files)
+    return all_files_dict
+
+
+def gather_files_all_procs(config: Configuration) -> Dict[str, List[str]]:
+    """Gather file paths for the various dataset files from all procs in config.
+
+    Parameters
+    ----------
+    config : Configuration
+        A configuration object
+
+    Returns
+    -------
+    Dict[str, Any]
+        A dictionary containing the various datasets file paths
+    """
+    all_files_dict = dict()
+    for proc in constants.DEFAULT_CONFIG_PROCS:
+        if getattr(config, proc):
+            all_files_dict.update(gather_files(config, proc))
     return all_files_dict
 
 
@@ -201,7 +223,7 @@ def get_transmit_times(
             transmit_times,
             atd_offsets,
             array_center,
-            constants.RPH_COLUMNS,
+            constants.RPH_LOCAL_TANGENTS,
             constants.GPS_GEOCENTRIC,
             constants.ANTENNA_DIRECTIONS,
         )
@@ -298,7 +320,7 @@ def get_reply_times(
             reply_times,
             atd_offsets,
             array_center,
-            constants.RPH_COLUMNS,
+            constants.RPH_LOCAL_TANGENTS,
             constants.GPS_GEOCENTRIC,
             constants.ANTENNA_DIRECTIONS,
         )


### PR DESCRIPTION
* Currently roll-pitch-heading loader function only accepts [time, roll, pitch, heading] rows. It should accept optional covariance rows "roll-roll", "roll-pitch", "roll-heading" ... .etc in the csv file as well.
* Add helper function gather_files_all_procs() that gathers file paths from all processes
* * Issue #222 