### PR TITLE
(feat) Configuration model changes breaking unittests

### DIFF
--- a/src/gnatss/configs/main.py
+++ b/src/gnatss/configs/main.py
@@ -4,7 +4,7 @@ The main configuration module containing base settings pydantic
 classes
 """
 import datetime
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 
 import numpy as np
 import pymap3d
@@ -48,7 +48,7 @@ class Configuration(BaseConfiguration):
     # General configurations
     site_id: str = Field(..., description="GNSS-A site name or code")
     campaign: Optional[str] = Field(None, description="Observation campaign name")
-    time_origin: Optional["str | datetime.datetime"] = Field(
+    time_origin: Optional[Union[str, datetime.datetime]] = Field(
         None, description="Origin of time used in the file [UTC]"
     )
     ref_frame: Literal["wgs84"] = Field(

--- a/tests/configs/test_main.py
+++ b/tests/configs/test_main.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-import pytest
-
 from gnatss.configs.main import Configuration
 
 
@@ -11,14 +9,7 @@ def test_env_configuration_main(blank_env: None) -> None:
 
     See root/conftest.py for fixture definition.
     """
-    with pytest.warns(
-        UserWarning,
-        match=(
-            "Configuration file `config.yaml` not found. "
-            "Will attempt to retrieve configuration from environment variables."
-        ),
-    ):
-        config = Configuration()
+    config = Configuration()
 
     assert config.site_id == "test_site"
 
@@ -31,14 +22,7 @@ def test_env_main_posfilter(blank_csv_test_file: Path, blank_env: None) -> None:
     """
     test_path = str(blank_csv_test_file)
 
-    with pytest.warns(
-        UserWarning,
-        match=(
-            "Configuration file `config.yaml` not found. "
-            "Will attempt to retrieve configuration from environment variables."
-        ),
-    ):
-        config = Configuration()
+    config = Configuration()
 
-    assert config.posfilter is not None
-    assert config.posfilter.input_files.roll_pitch_heading.path == test_path
+    # assert config.input_files.travel_times is populated
+    assert config.input_files.travel_times.path == test_path

--- a/tests/configs/test_posfilter.py
+++ b/tests/configs/test_posfilter.py
@@ -17,23 +17,28 @@ def test_valid_position_filter_input(blank_csv_test_file: Path) -> None:
     # Test initialization of PositionFilter
     input_files = PositionFilterInputs(roll_pitch_heading=InputData(path=test_path))
     atdoffsets = AtdOffset(forward=0.0, rightward=-1.2, downward=3.2)
+
     pos_filter = PositionFilter(input_files=input_files, atd_offsets=atdoffsets)
     assert pos_filter.input_files.roll_pitch_heading.path == test_path
+    assert pos_filter.atd_offsets.forward == 0.0
+    assert pos_filter.atd_offsets.rightward == -1.2
+    assert pos_filter.atd_offsets.downward == 3.2
+
+    pos_filter = PositionFilter(atd_offsets=atdoffsets)
+    assert pos_filter.input_files is None
+    assert pos_filter.atd_offsets.forward == 0.0
+    assert pos_filter.atd_offsets.rightward == -1.2
+    assert pos_filter.atd_offsets.downward == 3.2
 
 
 def test_invalid_position_filter_input(blank_csv_test_file: Path) -> None:
     test_path = str(blank_csv_test_file)
     input_files = PositionFilterInputs(roll_pitch_heading=InputData(path=test_path))
-    atdoffsets = AtdOffset(forward=0.0, rightward=-1.2, downward=3.2)
 
     with pytest.raises(ValidationError) as e:
         _ = PositionFilter()
-    assert "2 validation error for PositionFilter\ninput_files\n" not in str(e)
+    assert "1 validation error for PositionFilter\natd_offsets\n" in str(e)
 
     with pytest.raises(ValidationError) as e:
         _ = PositionFilter(input_files=input_files)
     assert "1 validation error for PositionFilter\natd_offsets\n" in str(e)
-
-    with pytest.raises(ValidationError) as e:
-        _ = PositionFilter(atd_offsets=atdoffsets)
-    assert "1 validation error for PositionFilter\ninput_files\n" in str(e)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+from json import dumps
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
@@ -17,12 +18,12 @@ def blank_csv_test_file() -> Path:
 def blank_env(blank_csv_test_file: Path) -> None:
     blank_envs = {
         "GNATSS_SITE_ID": "test_site",
-        "GNATSS_POSFILTER__INPUT_FILES__ROLL_PITCH_HEADING__PATH": str(
-            blank_csv_test_file
+        "GNATSS_ARRAY_CENTER__LAT": str(1.1),
+        "GNATSS_ARRAY_CENTER__LON": str(2.2),
+        "GNATSS_TRANSPONDERS": "[]",
+        "GNATSS_INPUT_FILES": dumps(
+            {"travel_times": {"path": str(blank_csv_test_file)}}
         ),
-        "GNATSS_POSFILTER__ATD_OFFSETS__FORWARD": str(0.000053),
-        "GNATSS_POSFILTER__ATD_OFFSETS__RIGHTWARD": str(0),
-        "GNATSS_POSFILTER__ATD_OFFSETS__DOWNWARD": str(0.92813),
     }
     for k, v in blank_envs.items():
         os.environ.setdefault(k, v)

--- a/tests/data/config.yaml
+++ b/tests/data/config.yaml
@@ -1,22 +1,39 @@
 site_id: NCL1
+array_center:
+  lat: 45.3023
+  lon: -124.9656
+transponders:
+  - lat: 45.302064471
+    lon: -124.978181346
+    height: -1176.5866
+    internal_delay: 0.200000
+    sv_mean: 1481.551
+  - lat: 45.295207747
+    lon: -124.958752845
+    height: -1146.5881
+    internal_delay: 0.320000
+    sv_mean: 1481.521
+  - lat: 45.309643593
+    lon: -124.959348875
+    height: -1133.7305
+    internal_delay: 0.440000
+    sv_mean: 1481.509
+input_files:
+  sound_speed:
+    path: ./tests/data/2022/NCL1/ctd/CTD_NCL1_Ch_Mi
+  travel_times:
+    path: ./tests/data/2022/NCL1/**/WG_*/pxp_tt
+  gps_solution:
+    path: ./tests/data/2022/NCL1/**/posfilter/POS_FREED_TRANS_TWTT
+  # deletions and quality_controls files are optional
+  # users should be able to also add their points in ./output/deletions.csv
+  # quality_controls:
+  #   path: ./tests/data/2022/NCL1/quality_control.csv
+  # deletions:
+  #   path: ./tests/data/2022/NCL1/deletns.dat
+
 
 solver:
-  transponders:
-    - lat: 45.302064471
-      lon: -124.978181346
-      height: -1176.5866
-      internal_delay: 0.200000
-      sv_mean: 1481.551
-    - lat: 45.295207747
-      lon: -124.958752845
-      height: -1146.5881
-      internal_delay: 0.320000
-      sv_mean: 1481.521
-    - lat: 45.309643593
-      lon: -124.959348875
-      height: -1133.7305
-      internal_delay: 0.440000
-      sv_mean: 1481.509
   reference_ellipsoid:
     semi_major_axis: 6378137.000
     reverse_flattening: 298.257222101
@@ -24,26 +41,10 @@ solver:
   std_dev: true
   geoid_undulation: -26.59
   bisection_tolerance: 1e-10
-  array_center:
-    lat: 45.3023
-    lon: -124.9656
   travel_times_variance: 1e-10
   travel_times_correction: 0.0
   transducer_delay_time: 0.0
   harmonic_mean_start_depth: -4.0
-  input_files:
-    sound_speed:
-      path: ./tests/data/2022/NCL1/ctd/CTD_NCL1_Ch_Mi
-    travel_times:
-      path: ./tests/data/2022/NCL1/**/WG_*/pxp_tt
-    gps_solution:
-      path: ./tests/data/2022/NCL1/**/posfilter/POS_FREED_TRANS_TWTT
-    # deletions and quality_controls files are optional
-    # users should be able to also add their points in ./output/deletions.csv
-    # quality_controls:
-    #   path: ./tests/data/2022/NCL1/quality_control.csv
-    # deletions:
-    #   path: ./tests/data/2022/NCL1/deletns.dat
 
 posfilter:
   atd_offsets:

--- a/tests/ops/test_data.py
+++ b/tests/ops/test_data.py
@@ -17,6 +17,7 @@ from .. import TEST_DATA_FOLDER
 
 @pytest.fixture()
 def all_observations() -> pd.DataFrame:
+    # TODO: Understand the contents of test_obs.csv file and fix unittests
     obs_csv = TEST_DATA_FOLDER / "test_obs.csv"
     return pd.read_csv(obs_csv)
 


### PR DESCRIPTION
* Remove typing "|" operator, since it is not supported in python 3.9
* Fix unittests in test_main, test_posfilter
* Closes Issue #240 