### PR TITLE
refactor: Extend calc_twtt_model to allow other methods

### DIFF
--- a/src/gnatss/configs/solver.py
+++ b/src/gnatss/configs/solver.py
@@ -186,3 +186,6 @@ class Solver(BaseModel):
     travel_times_correction: float = Field(
         0.0, description="Correction to times in travel times (secs.)"
     )
+    twtt_model: Literal["simple_twtt"] = Field(
+        "simple_twtt", description="Travel time model to use."
+    )

--- a/src/gnatss/solver/methods.py
+++ b/src/gnatss/solver/methods.py
@@ -1,0 +1,39 @@
+import numba
+import numpy as np
+from nptyping import Float64, NDArray, Shape
+
+
+@numba.njit(cache=True)
+def simple_twtt(
+    transmit_vectors: NDArray[Shape["*, 3"], Float64],
+    reply_vectors: NDArray[Shape["*, 3"], Float64],
+    transponders_mean_sv: NDArray[Shape["*"], Float64],
+) -> NDArray[Shape["*"], Float64]:
+    """
+    Calculate the Simple Modeled TWTT (Two way travel time) in seconds
+
+    .. math::
+        \\frac{\\hat{D_s} + \\hat{D_r}}{c}
+
+    Parameters
+    ----------
+    transmit_vector : (N,3) ndarray
+        The transmit array of vectors
+    reply_vector : (N,3) ndarray
+        The reply array of vectors
+    transponders_mean_sv : (N,) ndarray
+        The transponders mean sound speed
+
+    Returns
+    -------
+    (N,) ndarray
+        The modeled two way travel times in seconds
+
+    """
+    # Calculate distances in meters
+    transmit_distance = np.array(
+        [np.linalg.norm(vector) for vector in transmit_vectors]
+    )
+    reply_distance = np.array([np.linalg.norm(vector) for vector in reply_vectors])
+
+    return (transmit_distance + reply_distance) / transponders_mean_sv

--- a/src/gnatss/solver/run.py
+++ b/src/gnatss/solver/run.py
@@ -23,7 +23,10 @@ def run_solver(config, data_dict, return_raw: bool = False):
     )
     all_epochs = get_all_epochs(all_observations)
 
-    process_data, is_converged = prepare_and_solve(all_observations, config)
+    twtt_model = config.solver.twtt_model
+    process_data, is_converged = prepare_and_solve(
+        all_observations, config, twtt_model=twtt_model
+    )
 
     if is_converged:
         _print_final_stats(config.solver.transponders, process_data)

--- a/src/gnatss/solver/utilities.py
+++ b/src/gnatss/solver/utilities.py
@@ -1,5 +1,6 @@
 import warnings
-from typing import Any, Dict, List, Tuple
+from enum import StrEnum
+from typing import Any, Dict, List, Literal, Tuple
 
 import numpy as np
 import pandas as pd
@@ -15,6 +16,10 @@ from ..ops.validate import check_solutions
 from ..utilities.geo import _get_rotation_matrix
 from ..utilities.time import AstroTime
 from .solve import perform_solve
+
+
+class TWTTModel(StrEnum):
+    simple_twtt = "simple_twtt"
 
 
 def _print_detected_outliers(
@@ -363,7 +368,10 @@ def extract_distance_from_center(
 
 
 def prepare_and_solve(
-    all_observations: pd.DataFrame, config: Configuration, max_iter: int = 6
+    all_observations: pd.DataFrame,
+    config: Configuration,
+    max_iter: int = 6,
+    twtt_model: Literal["simple_twtt"] = "simple_twtt",
 ) -> Tuple[Dict[int, Any], bool]:
     """
     Prepare data inputs and perform solving algorithm
@@ -432,6 +440,7 @@ def prepare_and_solve(
             transponders_xyz,
             transponders_delay,
             travel_times_variance,
+            twtt_model,
         )
 
         is_converged, transponders_xyz, data = check_solutions(

--- a/src/gnatss/solver/utilities.py
+++ b/src/gnatss/solver/utilities.py
@@ -1,5 +1,4 @@
 import warnings
-from enum import StrEnum
 from typing import Any, Dict, List, Literal, Tuple
 
 import numpy as np
@@ -16,10 +15,6 @@ from ..ops.validate import check_solutions
 from ..utilities.geo import _get_rotation_matrix
 from ..utilities.time import AstroTime
 from .solve import perform_solve
-
-
-class TWTTModel(StrEnum):
-    simple_twtt = "simple_twtt"
 
 
 def _print_detected_outliers(


### PR DESCRIPTION
This PR add ability to extend the `calc_twtt_model` function and configuration of `twtt_model` for the `solver`. However, it is currently only "simple_twtt" that's available.