### PR TITLE
test: Remove the use of git lfs and add testing module

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-tests/data/2022.zip filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,17 +20,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0 # Fetch all history for all branches and tags.
-
-    - name: Create LFS file list
-      run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
-
-    - name: Restore LFS cache
-      uses: actions/cache@v2
-      id: lfs-cache
-      with:
-        path: .git/lfs
-        key: lfs-py${{ matrix.python-version }}-${{ hashFiles('.lfs-assets-id') }}
-
     - name: Setup Python
       uses: actions/setup-python@v5.1.0
       with:

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,15 +33,11 @@ def tests(session: nox.Session) -> None:
     - git-lfs: https://github.com/git-lfs/git-lfs
     - unzip: https://linuxize.com/post/how-to-unzip-files-in-linux/
     """
-    test_data_zip_path = (DIR / "tests" / "data" / "2022.zip").absolute()
     session.install(".[test]")
-    session.run("git", "lfs", "pull", external=True)
     session.run(
-        "unzip",
-        str(test_data_zip_path),
-        "-d",
-        str(test_data_zip_path.parent),
-        external=True,
+        "python",
+        "-c",
+        "from gnatss.utilities.testing import download_test_data; download_test_data(unzip=True)",
     )
     session.run("pytest", "-vvv", "tests", *session.posargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ test = [
     "pytest-mock",
     "pytest-xdist",
     "pytest-benchmark",
+    "PyGithub",
 ]
 
 [project.urls]

--- a/src/gnatss/utilities/testing.py
+++ b/src/gnatss/utilities/testing.py
@@ -1,0 +1,39 @@
+import shutil
+from pathlib import Path
+from typing import Optional
+from urllib.request import urlretrieve
+
+try:
+    from github import Github  # noqa
+except ImportError:
+    raise ImportError("Please install PyGithub: pip install PyGithub")
+
+TEST_DATA_REPO = "seafloor-geodesy/gnatss-test-data"
+
+# Open read-only authentication to Github
+gh = Github()
+PWD = Path(".")
+TEST_DATA_ZIP_FILE = (PWD / "tests" / "data" / "2022.zip").resolve()
+
+
+def download_test_data(zip_file_path: Optional[str] = None, unzip: bool = False):
+    if zip_file_path is not None:
+        global TEST_DATA_ZIP_FILE
+        TEST_DATA_ZIP_FILE = Path(zip_file_path).resolve()
+
+    repo = gh.get_repo(TEST_DATA_REPO)
+    release = repo.get_latest_release()
+    asset = next(asset for asset in release.get_assets())
+    url = asset.browser_download_url
+    print(f"Downloading test data from {url}")
+    path, _ = urlretrieve(url, str(TEST_DATA_ZIP_FILE))
+    print(f"Downloaded test data to {path}")
+
+    if unzip:
+        test_data_dir = TEST_DATA_ZIP_FILE.parent
+        print(f"Unzipping {path} to {test_data_dir}")
+        test_data_dir.mkdir(parents=True, exist_ok=True)
+        shutil.unpack_archive(path, test_data_dir, "zip")
+        print(f"Unzipped {path} to {test_data_dir}")
+        return str(test_data_dir)
+    return path

--- a/tests/data/2022.zip
+++ b/tests/data/2022.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c6b00a88f26e25c43594e47b8fdd44ed16205e94e04df48e1a499766705d911d
-size 284116077


### PR DESCRIPTION
This PR removes the use of git lfs. It is simply too restrictive for an open source workflow.

Closes #267 