### PR TITLE
test: Coverage report ignores Numba code

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,6 @@ exclude_lines =
     @numba.stencil
     @numba.guvectorize
     @numba.vectorize
+    pragma: no cover
+    if TYPE_CHECKING:
+    @overload

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,9 @@
 omit =
     */version.py
     */configs/*
+exclude_lines =
+    @numba.jit
+    @jit
+    @numba.stencil
+    @numba.guvectorize
+    @numba.vectorize


### PR DESCRIPTION
Ignore numba jit functions in the coveragerc file. This is a workaround that ignores these decorated functions, and does not include them in the coverage calclations.