### PR TITLE
fix: Ignore pings without replies from every transponder

### DIFF
--- a/src/gnatss/ops/data.py
+++ b/src/gnatss/ops/data.py
@@ -231,6 +231,37 @@ def get_data_inputs(all_observations: pd.DataFrame) -> NumbaList:
     return data_inputs
 
 
+def prefilter_replies(
+    all_observations: pd.DataFrame,
+    num_transponders: int,
+) -> pd.DataFrame:
+    """
+    Remove pings that do receive replies from each
+    transponder in the array.
+
+    Parameters
+    ----------
+    all_observations : pd.DataFrame
+        The original observations that include every ping and reply
+    num_transponders : int
+        The number of transponders in the array
+
+    Returns
+    -------
+    pd.DataFrame
+        The observations where the number of replies equal the
+        number of transponders
+    """
+    # Get value counts for transmit times
+    time_counts = all_observations[constants.DATA_SPEC.tx_time].value_counts()
+
+    return all_observations[
+        all_observations[constants.DATA_SPEC.tx_time].isin(
+            time_counts[time_counts == num_transponders].index
+        )
+    ]
+
+
 def clean_tt(
     travel_times: pd.DataFrame,
     transponder_ids: list[str],

--- a/src/gnatss/solver/utilities.py
+++ b/src/gnatss/solver/utilities.py
@@ -391,6 +391,7 @@ def prepare_and_solve(
     num_transponders = len(transponders)
 
     typer.echo("Preparing data inputs...")
+    typer.echo(f"Pre-filtering data with fewer than {num_transponders} replies...")
     reduced_observations = prefilter_replies(all_observations, num_transponders)
     data_inputs = get_data_inputs(reduced_observations)
 

--- a/src/gnatss/solver/utilities.py
+++ b/src/gnatss/solver/utilities.py
@@ -12,7 +12,7 @@ from pymap3d import ecef2enu, ecef2geodetic, geodetic2ecef
 from .. import constants
 from ..configs.main import Configuration
 from ..configs.solver import SolverTransponder
-from ..ops.data import filter_tt, get_data_inputs
+from ..ops.data import filter_tt, get_data_inputs, prefilter_replies
 from ..ops.validate import check_solutions
 from ..utilities.geo import _get_rotation_matrix
 from ..utilities.time import AstroTime
@@ -387,15 +387,18 @@ def prepare_and_solve(
     # Store original xyz
     original_positions = transponders_xyz.copy()
 
+    # Store number of transponders
+    num_transponders = len(transponders)
+
     typer.echo("Preparing data inputs...")
-    data_inputs = get_data_inputs(all_observations)
+    reduced_observations = prefilter_replies(all_observations, num_transponders)
+    data_inputs = get_data_inputs(reduced_observations)
 
     typer.echo("Perform solve...")
     is_converged = False
     n_iter = 0
-    num_transponders = len(transponders)
     process_dict = {}
-    num_data = len(all_observations)
+    num_data = len(reduced_observations)
     typer.echo(f"--- {len(data_inputs)} epochs, {num_data} measurements ---")
     while not is_converged:
         # Max converge attempt failure


### PR DESCRIPTION
This should address Issue #296.

I have chosen to directly compare the number of replies to the number of transponders for two reasons:
  1) I'm trying to lay groundwork to allow the software to handle arrays with >3 transponders.
  2) I'm trying to insulate the software from a theoretical bug where a large enough array makes it difficult (if not impossible) for every transponder to reply to a single ping, as was hinted at by @SquirrelKnight. If we tie the comparison to the max replies to a ping then that failure avenue is left open

This is a temporary fix, and in the future I think we should relax this constraint by making it optional. This would open the door to gnatss being able to process data from arrays described in point 2 above.