### PR TITLE
fix: Set posfilter files to no longer load when --from-cache set

### DIFF
--- a/src/gnatss/ops/data.py
+++ b/src/gnatss/ops/data.py
@@ -231,6 +231,37 @@ def get_data_inputs(all_observations: pd.DataFrame) -> NumbaList:
     return data_inputs
 
 
+def prefilter_replies(
+    all_observations: pd.DataFrame,
+    num_transponders: int,
+) -> pd.DataFrame:
+    """
+    Remove pings that do receive replies from each
+    transponder in the array.
+
+    Parameters
+    ----------
+    all_observations : pd.DataFrame
+        The original observations that include every ping and reply
+    num_transponders : int
+        The number of transponders in the array
+
+    Returns
+    -------
+    pd.DataFrame
+        The observations where the number of replies equal the
+        number of transponders
+    """
+    # Get value counts for transmit times
+    time_counts = all_observations[constants.DATA_SPEC.tx_time].value_counts()
+
+    return all_observations[
+        all_observations[constants.DATA_SPEC.tx_time].isin(
+            time_counts[time_counts == num_transponders].index
+        )
+    ]
+
+
 def clean_tt(
     travel_times: pd.DataFrame,
     transponder_ids: list[str],

--- a/src/gnatss/ops/io.py
+++ b/src/gnatss/ops/io.py
@@ -213,7 +213,7 @@ def load_datasets(
     # Gather main
     all_files_dict.update(gather_files(config, proc="main", mode=mode))
 
-    # Gather posfilter
+    # Gather posfilter (Skip if from_cache set)
     if not skip_posfilter and not from_cache:
         all_files_dict.update(gather_files(config, proc="posfilter", mode=mode))
 

--- a/src/gnatss/ops/io.py
+++ b/src/gnatss/ops/io.py
@@ -214,7 +214,7 @@ def load_datasets(
     all_files_dict.update(gather_files(config, proc="main", mode=mode))
 
     # Gather posfilter
-    if not skip_posfilter:
+    if not skip_posfilter and not from_cache:
         all_files_dict.update(gather_files(config, proc="posfilter", mode=mode))
 
     # Gather solver

--- a/src/gnatss/solver/utilities.py
+++ b/src/gnatss/solver/utilities.py
@@ -391,6 +391,7 @@ def prepare_and_solve(
     num_transponders = len(transponders)
 
     typer.echo("Preparing data inputs...")
+    typer.echo(f"Pre-filtering data with fewer than {num_transponders} replies...")
     reduced_observations = prefilter_replies(all_observations, num_transponders)
     data_inputs = get_data_inputs(reduced_observations)
 

--- a/src/gnatss/solver/utilities.py
+++ b/src/gnatss/solver/utilities.py
@@ -12,7 +12,7 @@ from pymap3d import ecef2enu, ecef2geodetic, geodetic2ecef
 from .. import constants
 from ..configs.main import Configuration
 from ..configs.solver import SolverTransponder
-from ..ops.data import filter_tt, get_data_inputs
+from ..ops.data import filter_tt, get_data_inputs, prefilter_replies
 from ..ops.validate import check_solutions
 from ..utilities.geo import _get_rotation_matrix
 from ..utilities.time import AstroTime
@@ -387,15 +387,18 @@ def prepare_and_solve(
     # Store original xyz
     original_positions = transponders_xyz.copy()
 
+    # Store number of transponders
+    num_transponders = len(transponders)
+
     typer.echo("Preparing data inputs...")
-    data_inputs = get_data_inputs(all_observations)
+    reduced_observations = prefilter_replies(all_observations, num_transponders)
+    data_inputs = get_data_inputs(reduced_observations)
 
     typer.echo("Perform solve...")
     is_converged = False
     n_iter = 0
-    num_transponders = len(transponders)
     process_dict = {}
-    num_data = len(all_observations)
+    num_data = len(reduced_observations)
     typer.echo(f"--- {len(data_inputs)} epochs, {num_data} measurements ---")
     while not is_converged:
         # Max converge attempt failure


### PR DESCRIPTION
This is a one-line fix that solves an issue where setting the "--from-cache" flag would not prevent gnatss from loading input files declared in the posfilter mode of the config file. Since some of these files are large (INSPVAA and INSSTDEVA files can be 10s of Gb) this saves a noticeable amount of processing time when --from-cache is set.

The actual functionality of gnatss when --from-cache is declared is not affected since it only runs the solver. Posfilter operations are not performed in this case.

Gnatss can still be run in posfilter mode when --from-cache is not declared, either by declaring --posfilter or by default.