### PR TITLE
ci: Fix failing ci tests due to deprecated disutils

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
           FORCE_COLOR: 3
         run: |
           set -o pipefail
-          nox -s tests -- --cov=${{ env.PROJECT_NAME }} --cov-report=xml --cov-report=term tests/ |& tee unit_test_log${{ matrix.python-version }}.log
+          nox --verbose -s tests -- --cov=${{ env.PROJECT_NAME }} --cov-report=xml --cov-report=term tests/ |& tee unit_test_log${{ matrix.python-version }}.log
       - name: Upload unit test log
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v4

--- a/noxfile.py
+++ b/noxfile.py
@@ -78,6 +78,9 @@ def tests(session: nox.Session) -> None:
     - git-lfs: https://github.com/git-lfs/git-lfs
     - unzip: https://linuxize.com/post/how-to-unzip-files-in-linux/
     """
+    # Specify the setuptools version
+    # https://numpy.org/doc/stable/reference/distutils_status_migration.html#distutils-status-migration
+    session.install("setuptools<60")
     session.install(".[test]")
     if not (DIR / "tests" / "data" / "2022").exists():
         session.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,11 @@ dependencies = [
     "fsspec>=2024.5.0,<2025",
     "matplotlib>=3.8.0,<4",
     "numba>=0.56.4,<1",
-    "numpy>=1.23.5,<2",
+    # numpy/f2py/f2py2e.py:719
+    # VisibleDeprecationWarning: distutils has been deprecated since NumPy 1.26.x
+    # Use the Meson backend instead, 
+    # or generate wrapperswithout -c and use a custom build script
+    "numpy>=1.23.5,<1.26",
     "nptyping>=2.5.0,<3",
     "cftime>=1.6.2,<2",
     "pandas>=2.0.3,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "numba>=0.56.4,<1",
     # numpy/f2py/f2py2e.py:719
     # VisibleDeprecationWarning: distutils has been deprecated since NumPy 1.26.x
-    # Use the Meson backend instead, 
+    # Use the Meson backend instead,
     # or generate wrapperswithout -c and use a custom build script
     "numpy>=1.23.5,<1.26",
     "nptyping>=2.5.0,<3",


### PR DESCRIPTION
This PR fixes the current failing tests caused by deprecation of disutils: https://numpy.org/doc/stable/reference/distutils_status_migration.html#distutils-status-migration... Due to this deprecation, the build backend for f2py is now meson: https://numpy.org/doc/stable/f2py/buildtools/meson.html. For now, we are just pinning versions to ensure that the software is not failing. Future migrations will be needed to support newer versions of numpy.