### PR TITLE
fix: Fix residual desync

### DIFF
--- a/src/gnatss/ops/data.py
+++ b/src/gnatss/ops/data.py
@@ -231,37 +231,6 @@ def get_data_inputs(all_observations: pd.DataFrame) -> NumbaList:
     return data_inputs
 
 
-def prefilter_replies(
-    all_observations: pd.DataFrame,
-    num_transponders: int,
-) -> pd.DataFrame:
-    """
-    Remove pings that do receive replies from each
-    transponder in the array.
-
-    Parameters
-    ----------
-    all_observations : pd.DataFrame
-        The original observations that include every ping and reply
-    num_transponders : int
-        The number of transponders in the array
-
-    Returns
-    -------
-    pd.DataFrame
-        The observations where the number of replies equal the
-        number of transponders
-    """
-    # Get value counts for transmit times
-    time_counts = all_observations[constants.DATA_SPEC.tx_time].value_counts()
-
-    return all_observations[
-        all_observations[constants.DATA_SPEC.tx_time].isin(
-            time_counts[time_counts == num_transponders].index
-        )
-    ]
-
-
 def clean_tt(
     travel_times: pd.DataFrame,
     transponder_ids: list[str],

--- a/src/gnatss/solver/run.py
+++ b/src/gnatss/solver/run.py
@@ -43,9 +43,7 @@ def run_solver(config, data_dict, return_raw: bool = False):
     resdf = extract_latest_residuals(config, all_epochs, process_data)
 
     if len(all_epochs) != len(resdf):  # pragma: no cover
-        msg = (
-            f"Warning! There is a mismatch between the number of observations ({len(all_epochs)})\n"
-        )
+        msg = f"Error: There is a mismatch between the number of observations ({len(all_epochs)})\n"
         msg += f"    and the number of residuals ({len(resdf)}).\n"
         msg += "Residuals have likely been assigned erroneous timestamps."
         raise ValueError(msg)

--- a/src/gnatss/solver/run.py
+++ b/src/gnatss/solver/run.py
@@ -42,13 +42,13 @@ def run_solver(config, data_dict, return_raw: bool = False):
     # Extract the latest run residuals
     resdf = extract_latest_residuals(config, all_epochs, process_data)
 
-    if len(all_epochs) != len(resdf):
+    if len(all_epochs) != len(resdf):  # pragma: no cover
         msg = (
             f"Warning! There is a mismatch between the number of observations ({len(all_epochs)})\n"
         )
         msg += f"    and the number of residuals ({len(resdf)}).\n"
         msg += "Residuals have likely been assigned erroneous timestamps."
-        raise RuntimeWarning(msg)
+        raise ValueError(msg)
 
     # Get the outliers
     outliers_df = get_residual_outliers(config, resdf)

--- a/src/gnatss/solver/run.py
+++ b/src/gnatss/solver/run.py
@@ -11,6 +11,7 @@ from .utilities import (
     generate_process_xr_dataset,
     get_all_epochs,
     get_residual_outliers,
+    prefilter_replies,
     prepare_and_solve,
 )
 
@@ -27,6 +28,9 @@ def run_solver(config, data_dict, return_raw: bool = False):
     all_observations = filter_deletions_and_qc(all_observations, data_dict)
     all_observations = check_sig3d(all_observations, config.solver.gps_sigma_limit)
     all_observations, dist_center_df = filter_by_distance_limit(all_observations, config)
+    # Pre-filter observations for reply number
+    all_observations = prefilter_replies(all_observations, len(config.transponders))
+
     all_epochs = get_all_epochs(all_observations)
 
     twtt_model = config.solver.twtt_model
@@ -37,6 +41,14 @@ def run_solver(config, data_dict, return_raw: bool = False):
 
     # Extract the latest run residuals
     resdf = extract_latest_residuals(config, all_epochs, process_data)
+
+    if len(all_epochs) != len(resdf):
+        msg = (
+            f"Warning! There is a mismatch between the number of observations ({len(all_epochs)})\n"
+        )
+        msg += f"    and the number of residuals ({len(resdf)}).\n"
+        msg += "Residuals have likely been assigned erroneous timestamps."
+        raise RuntimeWarning(msg)
 
     # Get the outliers
     outliers_df = get_residual_outliers(config, resdf)


### PR DESCRIPTION
This pr should fix the bug highlighted in issue #341. Specific changes include:

  -prefilter subroutine that removes pings with replies<num_transponders has been moved out of prepare_and_solve() and into run_solver(), which should allow it to execute before the creation of the all_epochs variable that controls residual timestamps.
  -In case there remains a difference in the number of epochs and the number of residuals, a check has been implemented before residual flagging that will trigger an error if they do not match. I do not expect this to ever trigger without further modification to the code, but in case a similar issue arises in the future I hope this will make it much easier to identify. (This was a silent bug.)
  -I have moved the prefilter code from ops/data.py to solver/utilities.py so that it is defined alongside other subroutines for removing pings before the solver is executed, such as removing deletions or distance outliers.