### PR TITLE
chore(deps): Update dependencies for np>1.26

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         experimental: [false]
     steps:
       - name: Checkout Repo

--- a/noxfile.py
+++ b/noxfile.py
@@ -87,7 +87,7 @@ def tests(session: nox.Session) -> None:
         )
     with session.chdir("tests/fortran"):
         # Runs in the tests fortran directory
-        session.run("f2py", "-c", "-m", "flib", "xyz2enu.f")
+        session.run("f2py", "-c", "--backend=meson", "-m", "flib", "xyz2enu.f")
 
     # Run in original directory
     session.run("pytest", *session.posargs)

--- a/noxfile.py
+++ b/noxfile.py
@@ -78,9 +78,6 @@ def tests(session: nox.Session) -> None:
     - git-lfs: https://github.com/git-lfs/git-lfs
     - unzip: https://linuxize.com/post/how-to-unzip-files-in-linux/
     """
-    # Specify the setuptools version
-    # https://numpy.org/doc/stable/reference/distutils_status_migration.html#distutils-status-migration
-    session.install("setuptools<60")
     session.install(".[test]")
     if not (DIR / "tests" / "data" / "2022").exists():
         session.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "astropy>=5.2.2,<6",
+    "astropy>=7.1.0,<8",
     "fsspec>=2024.5.0,<2025",
     "matplotlib>=3.8.0,<4",
     "numba>=0.56.4,<1",
@@ -28,7 +28,7 @@ dependencies = [
     # VisibleDeprecationWarning: distutils has been deprecated since NumPy 1.26.x
     # Use the Meson backend instead,
     # or generate wrapperswithout -c and use a custom build script
-    "numpy>=1.23.5,<1.26",
+    "numpy>1.26,<2",
     "nptyping>=2.5.0,<3",
     "cftime>=1.6.2,<2",
     "pandas>=2.0.3,<3",
@@ -55,6 +55,8 @@ docs = [
 ]
 test = [
     "nox",
+    "meson",
+    "ninja>1.8.2",
     "pre-commit",
     "hypothesis",
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "astropy>=7.1.0,<8",
+    "astropy>=6.1.7,<8",
     "fsspec>=2024.5.0,<2025",
     "matplotlib>=3.8.0,<4",
     "numba>=0.56.4,<1",


### PR DESCRIPTION
This pull request introduces updates to the CI pipeline, dependency management, and build/test configurations to support newer Python versions and modernize the toolchain. The most significant changes include expanding Python version support, updating dependencies, and migrating to the Meson build system for Fortran extensions.

### CI and Python Version Support:
* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL20-R20): Added support for Python 3.12 and 3.13 in the CI matrix to ensure compatibility with newer Python versions.

### Dependency Updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L23-R31): Updated `astropy` dependency to `>=6.1.7,<8` and `numpy` dependency to `>1.26,<2` to align with the latest library versions and address deprecation warnings.

### Build System Modernization:
* [`noxfile.py`](diffhunk://#diff-f7a16a65f061822bcc73b8296f4dc837353d379d8d9cc5307982cb6941442835L93-R90): Replaced the `f2py` build command with the Meson backend (`--backend=meson`) for building Fortran extensions, addressing deprecation of the distutils-based backend.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R58-R59): Added `meson` and `ninja>1.8.2` to test dependencies to support the new build system.

### Cleanup:
* [`noxfile.py`](diffhunk://#diff-f7a16a65f061822bcc73b8296f4dc837353d379d8d9cc5307982cb6941442835L81-L83): Removed the explicit installation of an older `setuptools` version, as it is no longer required for compatibility.

---
Fixes: https://github.com/seafloor-geodesy/gnatss/issues/312