### PR TITLE
Update config

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ this command by running `gnatss run --help`.
 │ --residual-limit                                             FLOAT  Maximum residual in centimeters beyond which data points will be excluded from solution.    │
 │                                                                     Note that this will override the value set as configuration.                                │
 │                                                                     [default: None]                                                                             │
+│ --residual-range-limit                                       FLOAT  Maximum residual range (maximum - minimum) in centimeters for a given epoch, beyond         │
+│                                                                     which data points will be excluded from solution. Note that this will override the          │
+│                                                                     value set as configuration.                                                                 │
+│                                                                     [default: None]                                                                             │
 │ --qc                         --no-qc                                Flag to plot residuals from run and store in output folder. [default: qc]                   │
 │ --from-cache                 --no-from-cache                        Flag to load the GNSS-A Level-2 Data from cache. [default: no-from-cache]                   │
 │ --remove-outliers            --no-remove-outliers                   Flag to execute removing outliers from the GNSS-A Level-2 Data before running the solver    │
@@ -133,11 +137,6 @@ travel_times_variance: 1e-10 #Default value
 travel_times_correction: 0.0 #Default value
 transducer_delay_time: 0.0 #Default value
 
-# Main input files
-input_files:
-  travel_times: #Assume Chadwell format, (Time at Ping send [DD-MON-YY HH:MM:SS.ss], TWTT1 (microseconds), TWTT2, TWTT3, TWTT4), TWTT=0 if no reply
-    path: /path/to/pxp_tt
-
 # Posfilter configuration
 posfilter:
   export:
@@ -153,6 +152,8 @@ posfilter:
       path: /path/to/file #File with INSSTDEVA strings
     gps_positions: #Assume Chadwell format, (j2000 seconds, "GPSPOS" string, ECEF XYZ coordinates (m), XYZ Standard Deviations)
       path: /path/to/GPS_POS_FREED #File path to antenna positions, use wildcards ** for day-separated data
+    travel_times: #Assume Chadwell format, (Time at Ping send [DD-MON-YY HH:MM:SS.ss], TWTT1 (microseconds), TWTT2, TWTT3, TWTT4), TWTT=0 if no reply
+      path: /path/to/pxp_tt
 
 # Solver configuration
 solver:

--- a/docs/config_yaml.md
+++ b/docs/config_yaml.md
@@ -8,15 +8,14 @@ The configuration file is divided into multiple sections, but not all of the
 sections are required depending on your processing needs. In general, GNATSS
 operates in two modes, a posfilter mode which performs pre-processing on wave
 glider data to generate input required for array positioning, and a solver mode
-that perms the array positioning using the data computed by the posfilter. These
-modes are defined separately in the config file. It is possible to run only one
-of these two modes at a time, or to run both in sequence, so it is optional to
-include their information in the config file.
+that performs the array positioning using the data computed by the posfilter.
+These modes are defined separately in the config file. It is possible to run
+only one of these two modes at a time, or to run both in sequence, so it is
+optional to include their information in the config file.
 
 At a high level, the sections of the configuration file are:
 
 - Metadata _(required)_: Information about the array
-- Main Input files _(required for posfilter)_: Travel time files
 - Posfilter configuration _(optional)_: Pre-processing configuration
 - Solver _(optional)_: Array positioning configuration
 - Output configuration _(required)_: Destination for output files
@@ -54,11 +53,6 @@ travel_times_variance: 1e-10 #Default value
 travel_times_correction: 0.0 #Default value
 transducer_delay_time: 0.0 #Default value
 
-# Main input files
-input_files:
-  travel_times: #Assume Chadwell format, (Time at Ping send [DD-MON-YY HH:MM:SS.ss], TWTT1 (microseconds), TWTT2, TWTT3, TWTT4), TWTT=0 if no reply
-    path: /path/to/pxp_tt
-
 # Posfilter configuration
 posfilter:
   export:
@@ -74,6 +68,8 @@ posfilter:
       path: /path/to/file #File with INSSTDEVA strings
     gps_positions: #Assume Chadwell format, (j2000 seconds, "GPSPOS" string, ECEF XYZ coordinates (m), XYZ Standard Deviations)
       path: /path/to/GPS_POS_FREED #File path to antenna positions, use wildcards ** for day-separated data
+    travel_times: #Assume Chadwell format, (Time at Ping send [DD-MON-YY HH:MM:SS.ss], TWTT1 (microseconds), TWTT2, TWTT3, TWTT4), TWTT=0 if no reply
+      path: /path/to/pxp_tt
 
 # Solver configuration
 solver:
@@ -141,14 +137,6 @@ The information that should be defined in the config.yaml file is as follows:
   delay from the TWTT measurements before running GNATSS or else the TWTT
   measurements will be systematically inflated by the delay.
 
-### Main input files
-
-- **Travel Times** The TWTT input file is required for the posfilter mode.
-  GNATSS assumes this file is in the legacy Chadwell format (See
-  [_Required Input Data_](./input.md)).
-  - The user may input a file path to a single input file or use the UNIX "\*\*"
-    wildcard to point to multiple input files, such as day-separated data.
-
 ### Posfilter configuration
 
 - **Export** The _full_ parameter determines whether to include roll, pitch, and
@@ -171,6 +159,11 @@ The information that should be defined in the config.yaml file is as follows:
     processing software of their choice, such as PRIDE PPP-AR, GAMIT, or GipsyX.
     Regardless of the GNSS software used, GNATSS assumes that the solution has
     been converted into a legacy Chadwell format (See
+    [_Required Input Data_](./input.md)).
+  - The TWTT input file contains the ranges collected by the surface platform to
+    every transponder in the array. These ranges should include the internal
+    delay of the transponders but exclude the transducer delay time. GNATSS
+    assumes this file is in the legacy Chadwell format (See
     [_Required Input Data_](./input.md)).
 
 ### Solver configuration
@@ -200,10 +193,10 @@ The information that should be defined in the config.yaml file is as follows:
   - GPS Solution file, containing the transducer positions and TWTTs in the
     [GNSS-Acoustic Standard Data Format](https://hal.science/hal-04319233/).
     Only required if not running the posfilter mode. If running end-to-end
-    processing by calling the posfilter and solver module, the gps*solution.csv
-    file will be generated in the output path and can be automatically loaded by
-    calling the *--from-cache\_ flag when running GNATSS, in which case a file
-    path does not need to be designated.
+    processing by calling the posfilter and solver module, the
+    _gps_solution.csv_ file will be generated in the output path and can be
+    automatically loaded by calling the _--from-cache_ flag when running GNATSS,
+    in which case a file path does not need to be designated.
   - Quality Control file
 
 ### Output configuration

--- a/docs/gnssa_derivation.md
+++ b/docs/gnssa_derivation.md
@@ -5,7 +5,8 @@ a transducer at the sea surface at some known position $X_G$. Let the
 line-of-sight distance between the transponder and transducer be denoted by
 $\vec{D}_1=X_1-X_G$, and assume the water column consists of a single layer with
 sound velocity $c$. Under such conditions, the one-way travel time of an
-acoustic pulse a1 between the transponder and the transducer may be written as
+acoustic pulse $a_1$ between the transponder and the transducer may be written
+as
 
 $$\frac{||\vec{D}_1||}{c}=a+1,$$
 
@@ -95,14 +96,14 @@ although in practice there are some more steps we must take when interpreting
 some data.
 
 The observations used in this inversion are not perfect, so it is a good idea to
-construct a weighting matrix W which depends on the uncertainties of the travel
-time residuals. The travel time residuals have uncertainties dependent on three
-sources: the acoustic measurement uncertainty of the transducer, the position
-uncertainty of the transducer when the acoustic pulse is sent, and the position
-uncertainty of the transducer when the return acoustic pulse is received. Let
-$\sigma_a^2$ be the variance of an acoustic measurement, $C_S$ be the
-$3 \times 3$ covariance matrix of the transducer position $X_S$, and $C_R$ be
-the $3 \times 3$ covariance matrix of the transducer position $X_R$. Assuming
+construct a weighting matrix $W$ which depends on the uncertainties of the
+travel time residuals. The travel time residuals have uncertainties dependent on
+three sources: the acoustic measurement uncertainty of the transducer, the
+position uncertainty of the transducer when the acoustic pulse is sent, and the
+position uncertainty of the transducer when the return acoustic pulse is
+received. Let $\sigma_a^2$ be the variance of an acoustic measurement, $C_S$ be
+the $3 \times 3$ covariance matrix of the transducer position $X_S$, and $C_R$
+be the $3 \times 3$ covariance matrix of the transducer position $X_R$. Assuming
 that $\Delta a$ is a stochastic variable, the error propagation to derive the
 $i \times i$ matrix $W$ may be written out as:
 
@@ -113,11 +114,11 @@ $$
 Note that in the above formulation, the partial derivatives simplify to:
 
 $$
-\frac{\partial \Delta \vec{a}}{\partial X_S} = \left( \frac{\hat{D}_{1S}}{c_1}, \frac{\hat{D}_{2S}}{c2}, \cdots , \frac{\hat{D}_{iS}}{ci} \right),
+\frac{\partial \Delta \vec{a}}{\partial X_S} = \left( \frac{\hat{D}_{1S}}{c_1}, \frac{\hat{D}_{2S}}{c_2}, \cdots , \frac{\hat{D}_{iS}}{c_i} \right),
 $$
 
 $$
-\frac{\partial \Delta \vec{a}}{\partial X_R} = \left( \frac{\hat{D}_{1R}}{c_1}, \frac{\hat{D}_{2R}}{c2}, \cdots , \frac{\hat{D}_{iR}}{ci} \right)
+\frac{\partial \Delta \vec{a}}{\partial X_R} = \left( \frac{\hat{D}_{1R}}{c_1}, \frac{\hat{D}_{2R}}{c_2}, \cdots , \frac{\hat{D}_{iR}}{c_i} \right)
 $$
 
 As another unit check, the elements in the partial derivatives above all have

--- a/docs/gnssa_preprocessing.md
+++ b/docs/gnssa_preprocessing.md
@@ -27,7 +27,7 @@ collects the following data:
   process at 1 or 10 HZ for GNSS antenna positions
 - Wave glider velocities and roll, pitch, heading values at a 20 Hz sampling
   rate
-- Acoustic interrogation and rely times. The interrogation times have a sampling
+- Acoustic interrogation and reply times. The interrogation times have a sampling
   rate of 1 ping every 15 seconds, and there is one reply for each transponder
   in the array at arbitrary times after interrogation dependent on the ray path
   length.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,8 +1,7 @@
 # Installation Guide
 
-GNATSS requires Python v3.10 or v3.11 to run. It is not currently compatible
-with Python 3.12. If you have a conda installation, we recommend creating a
-fresh environment to install GNATSS in.
+GNATSS is compatible with Python versions 3.10-3.13. If you have a conda
+installation, we recommend creating a fresh environment to install GNATSS in.
 
 ```
 conda create -n gnatss -c conda-forge --yes python=3.10 ipykernel

--- a/src/gnatss/configs/io.py
+++ b/src/gnatss/configs/io.py
@@ -30,7 +30,7 @@ class InputData(BaseModel):
         ...,
         description="Path string to the data. Ex. s3://bucket/some_data.dat",
     )
-    format: str | None = Field(..., default=None, description="File format of the data.")
+    format: str | None = Field(..., description="File format of the data.")
     storage_options: dict[str, Any] = Field(
         {},
         description=(

--- a/src/gnatss/configs/io.py
+++ b/src/gnatss/configs/io.py
@@ -30,7 +30,7 @@ class InputData(BaseModel):
         ...,
         description="Path string to the data. Ex. s3://bucket/some_data.dat",
     )
-    format: dict[str, Any] = Field(..., description="File format of the data.")
+    format: str | None = Field(..., default=None, description="File format of the data.")
     storage_options: dict[str, Any] = Field(
         {},
         description=(

--- a/src/gnatss/configs/io.py
+++ b/src/gnatss/configs/io.py
@@ -30,6 +30,7 @@ class InputData(BaseModel):
         ...,
         description="Path string to the data. Ex. s3://bucket/some_data.dat",
     )
+    format: dict[str, Any] = Field(..., description="File format of the data.")
     storage_options: dict[str, Any] = Field(
         {},
         description=(

--- a/src/gnatss/configs/io.py
+++ b/src/gnatss/configs/io.py
@@ -30,7 +30,7 @@ class InputData(BaseModel):
         ...,
         description="Path string to the data. Ex. s3://bucket/some_data.dat",
     )
-    format: str | None = Field(..., description="File format of the data.")
+    format: str | None = Field(None, description="File format of the data.")
     storage_options: dict[str, Any] = Field(
         {},
         description=(

--- a/src/gnatss/configs/main.py
+++ b/src/gnatss/configs/main.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from ..utilities.geo import ecef2ae
-from .io import InputData, OutputPath
+from .io import OutputPath
 from .posfilter import PositionFilter
 from .solver import Solver
 from .transponders import Transponder
@@ -39,10 +39,10 @@ class ArrayCenter(BaseModel):
     alt: float = Field(0.0, description="Altitude")
 
 
-class MainInputs(BaseModel):
-    travel_times: InputData | None = Field(
-        None, description="Input travel times data path specification"
-    )
+# class MainInputs(BaseModel):
+#     travel_times: InputData | None = Field(
+#         None, description="Input travel times data path specification"
+#     )
 
 
 class Configuration(BaseConfiguration):
@@ -75,7 +75,7 @@ class Configuration(BaseConfiguration):
     posfilter: PositionFilter | None = Field(None, description="Position filter configurations")
 
     # File related configurations
-    input_files: MainInputs = Field(..., description="Input files data path specifications.")
+    # input_files: MainInputs = Field(..., description="Input files data path specifications.")
     output: OutputPath | None = Field(None, description="Output path configurations")
 
     # Extra configurations

--- a/src/gnatss/configs/posfilter.py
+++ b/src/gnatss/configs/posfilter.py
@@ -28,6 +28,9 @@ class PositionFilterInputs(BaseModel):
     gps_positions: InputData | None = Field(
         None, description="GPS positions data path specification."
     )
+    travel_times: InputData | None = Field(
+        None, description="Input travel times data path specification"
+    )
 
 
 class ExportObs(BaseModel):

--- a/src/gnatss/constants.py
+++ b/src/gnatss/constants.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from .dataspec import DataSpec
 
 # Config constants
-DEFAULT_CONFIG_PROCS = ("main", "solver", "posfilter")
+DEFAULT_CONFIG_PROCS = ("solver", "posfilter")
 
 DATA_SPEC = DataSpec(version="v1")
 

--- a/src/gnatss/ops/io.py
+++ b/src/gnatss/ops/io.py
@@ -117,7 +117,7 @@ def set_limits(
 
 def gather_files(
     config: Configuration,
-    proc: Literal["main", "solver", "posfilter"] = "solver",
+    proc: Literal["solver", "posfilter"] = "solver",
     mode: Literal["files", "object"] = "files",
 ) -> dict[str, list[str | InputData]]:
     """Gather file paths for the various dataset files defined in proc config.
@@ -135,14 +135,12 @@ def gather_files(
         A dictionary containing the various datasets file paths
     """
     all_files_dict = {}
-    if proc == "main":
-        proc_config = config
-    else:
-        # Check for process type first
-        if not hasattr(config, proc):
-            msg: str = f"Unknown process type: {proc}"
-            raise AttributeError(msg)
-        proc_config = getattr(config, proc)
+
+    # Check for process type first
+    if not hasattr(config, proc):
+        msg: str = f"Unknown process type: {proc}"
+        raise AttributeError(msg)
+    proc_config = getattr(config, proc)
 
     if proc_config:
         input_files = proc_config.input_files
@@ -184,7 +182,7 @@ def gather_files_all_procs(
             # if we are loading solution from cache
             continue
 
-        if proc == "main" or hasattr(config, proc):
+        if proc == hasattr(config, proc):
             all_files_dict.update(gather_files(config, proc, mode))
     return all_files_dict
 
@@ -215,9 +213,6 @@ def load_datasets(
 ):
     all_files_dict = {}
     mode = "object"
-
-    # Gather main
-    all_files_dict.update(gather_files(config, proc="main", mode=mode))
 
     # Gather posfilter (Skip if from_cache set)
     if not skip_posfilter and not from_cache:

--- a/tests/configs/test_configs_posfilter.py
+++ b/tests/configs/test_configs_posfilter.py
@@ -15,13 +15,15 @@ def test_valid_position_filter_input(blank_csv_test_file: Path) -> None:
     See root/conftest.py for fixture definition.
     """
     test_path = str(blank_csv_test_file)
+    test_format = "RPH"
 
     # Test initialization of PositionFilter
-    input_files = PositionFilterInputs(roll_pitch_heading=InputData(path=test_path))
+    input_files = PositionFilterInputs(roll_pitch_heading=InputData(path=test_path,format=test_format))
     atdoffsets = AtdOffset(forward=0.0, rightward=-1.2, downward=3.2)
 
     pos_filter = PositionFilter(input_files=input_files, atd_offsets=atdoffsets)
     assert pos_filter.input_files.roll_pitch_heading.path == test_path
+    assert pos_filter.input_files.roll_pitch_heading.format == test_format
     assert pos_filter.atd_offsets.forward == 0.0
     assert pos_filter.atd_offsets.rightward == -1.2
     assert pos_filter.atd_offsets.downward == 3.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def blank_env(blank_csv_test_file: Path) -> None:
         "GNATSS_ARRAY_CENTER__LAT": str(1.1),
         "GNATSS_ARRAY_CENTER__LON": str(2.2),
         "GNATSS_TRANSPONDERS": "[]",
-        "GNATSS_INPUT_FILES": dumps({"travel_times": {"path": str(blank_csv_test_file)}}),
+        # "GNATSS_INPUT_FILES": dumps({"travel_times": {"path": str(blank_csv_test_file)}}),
     }
     for k, v in blank_envs.items():
         os.environ.setdefault(k, v)

--- a/tests/data/config.yaml
+++ b/tests/data/config.yaml
@@ -25,9 +25,9 @@ travel_times_correction: 0.0
 transducer_delay_time: 0.0
 
 # Main input files
-input_files:
-  travel_times:
-    path: ./tests/data/2022/NCL1/**/WG_*/pxp_tt
+# input_files:
+#   travel_times:
+#     path: ./tests/data/2022/NCL1/**/WG_*/pxp_tt
 
 # Posfilter configuration
 posfilter:
@@ -44,6 +44,8 @@ posfilter:
       path: ./tests/data/2022/NCL1/NOV/NCL1_INSSTDEVA.dat
     gps_positions:
       path: ./tests/data/2022/NCL1/**/GPS_PPP/GPS_POS_FREED
+    travel_times:
+      path: ./tests/data/2022/NCL1/**/WG_*/pxp_tt
 
 # Solver configuration
 solver:

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -40,7 +40,7 @@ from tests import TEST_DATA_FOLDER
 @pytest.fixture()
 def all_files_dict_j2k_travel_times() -> dict[str, Any]:
     config = load_configuration(TEST_DATA_FOLDER / "config.yaml")
-    config.input_files.travel_times = InputData(path="./tests/data/2022/NCL1/**/WG_*/pxp_tt_j2k")
+    config.posfilter.input_files.travel_times = InputData(path="./tests/data/2022/NCL1/**/WG_*/pxp_tt_j2k")
     return gather_files_all_procs(config)
 
 


### PR DESCRIPTION
This PR is meant to address issue #356 and makes the following changes:

  -Adds generic "format" option to the InputData field used throughout the configuration file. This is currently optional and not used anywhere in the code, but allows us the ability to develop tools for reading inputs from multiple file types in the future.
  -Adds a test to make sure that the format exists when reading an example InputData field.
  -Moves the travel time input from "main" to "posfilter" in the config file. Removes references to loading input data from "main" and instead only loads data from "posfilter" or "solver", if those options are set.
  -Updates documentation to reflect these changes.

Note that currently the pytest infrastructure is failing due to the removal of the input data from "main". The issue appears to stem from an empty _all_files_dict_ array, meaning that no input files from any mode are being recognized. However, an independent test run processing data in a jupyter notebook with the new configuration file structure was successful. As it stands, feedback on the potential issue here and a way to test this changes is required.