### PR TITLE
chore: Set pytest<9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ test = [
     "ninja>1.8.2",
     "pre-commit",
     "hypothesis",
-    "pytest",
+    "pytest<9.1",
     "pytest-cov",
     "pytest-flake8",
     "pytest-mock",


### PR DESCRIPTION
Pytest v9.1 breaks the nox testing apparatus, so I have updated the dependency to pytest<9.1.