### PR TITLE
Dfo bugfix

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -2531,7 +2531,7 @@ packages:
   requires_python: '>=3.8'
 - pypi: ./
   name: gnatss
-  version: 0.1.dev342
+  version: 0.1.dev357
   sha256: 90b938b2aaed7eb207f4992678e560e263df4269ad48637e42e7c72c067b4765
   requires_dist:
   - astropy>=6.1.7,<8

--- a/src/gnatss/loaders.py
+++ b/src/gnatss/loaders.py
@@ -209,7 +209,7 @@ def load_dfo(
                 event = pin_json["event"]
 
                 # Truncated data export for ping transmit
-                if event == "interrogation":
+                if event == "interrogation" and pin_json["observations"]["GNSS"] != "ERR3":
                     T_transmit = AstroTime(
                         pin_json["observations"]["GNSS"]["time"]["common"],
                         format="unix",

--- a/src/gnatss/loaders.py
+++ b/src/gnatss/loaders.py
@@ -207,16 +207,16 @@ def load_dfo(
                 try:
                     pin_json = json.loads(line_pin)
                 except json.JSONDecodeError:
-                    skip = True #Skip remaining returns in ping if record corrupted
+                    skip = True  # Skip remaining returns in ping if record corrupted
                     continue
 
                 # Log event designation
                 event = pin_json["event"]
 
                 if event == "interrogation":
-                    skip = False #Reset if uncorrupted iterrogation
+                    skip = False  # Reset if uncorrupted iterrogation
                 if skip:
-                    continue #Skip ping returns if previous record in ping corrupted
+                    continue  # Skip ping returns if previous record in ping corrupted
 
                 # Check for missing GNSS data in interrogation
                 if event == "interrogation" and pin_json["observations"]["GNSS"] == "ERR3":
@@ -422,7 +422,6 @@ def load_sv3_targz(
             if Path.stat(Path(temp_dir_path + "/" + file.name)).st_size != 0:
                 with Path(temp_dir_path + "/" + file.name).open() as pin_file:
                     for line_pin in pin_file:
-
                         try:
                             pin_json = json.loads(line_pin)
                         except json.JSONDecodeError:
@@ -467,7 +466,6 @@ def load_sv3_targz(
 
                         # Gather reply values and write to list
                         for pin_event in pin_json:
-
                             if pin_json["interrogation"]["observations"]["GNSS"] == "ERR3":
                                 continue
 

--- a/src/gnatss/loaders.py
+++ b/src/gnatss/loaders.py
@@ -199,6 +199,7 @@ def load_dfo(
     SITE = config.site_id
 
     temp_list = []
+    skip = False
 
     for file in file_paths:
         with Path(file).open() as pin_file:
@@ -206,13 +207,24 @@ def load_dfo(
                 try:
                     pin_json = json.loads(line_pin)
                 except json.JSONDecodeError:
+                    skip = True #Skip remaining returns in ping if record corrupted
                     continue
 
                 # Log event designation
                 event = pin_json["event"]
 
+                if event == "interrogation":
+                    skip = False #Reset if uncorrupted iterrogation
+                if skip:
+                    continue #Skip ping returns if previous record in ping corrupted
+
+                # Check for missing GNSS data in interrogation
+                if event == "interrogation" and pin_json["observations"]["GNSS"] == "ERR3":
+                    skip = True
+                    continue
+
                 # Truncated data export for ping transmit
-                if event == "interrogation" and pin_json["observations"]["GNSS"] != "ERR3":
+                if event == "interrogation":
                     T_transmit = AstroTime(
                         pin_json["observations"]["GNSS"]["time"]["common"],
                         format="unix",

--- a/src/gnatss/loaders.py
+++ b/src/gnatss/loaders.py
@@ -397,14 +397,24 @@ def load_sv3_targz(
         # Iterate through targz files and extract .pin files to temp directory
         for file_list in file_paths:
             with tarfile.open(file_list) as zipfile:
-                zipfile.extractall(temp_dir_path)
+                try:
+                    zipfile.extractall(temp_dir_path)
+                except EOFError:
+                    continue
 
         # Read through .pin files and extract data
         for file in list(Path(temp_dir_path).rglob("*.pin")):
             if Path.stat(Path(temp_dir_path + "/" + file.name)).st_size != 0:
                 with Path(temp_dir_path + "/" + file.name).open() as pin_file:
                     for line_pin in pin_file:
-                        pin_json = json.loads(line_pin)
+
+                        try:
+                            pin_json = json.loads(line_pin)
+                        except json.JSONDecodeError:
+                            continue
+
+                        if pin_json["interrogation"]["observations"]["GNSS"] == "ERR3":
+                            continue
 
                         # Read transmit values
                         T_transmit = AstroTime(
@@ -442,6 +452,10 @@ def load_sv3_targz(
 
                         # Gather reply values and write to list
                         for pin_event in pin_json:
+
+                            if pin_json["interrogation"]["observations"]["GNSS"] == "ERR3":
+                                continue
+
                             # Log event designation
                             event = pin_json[pin_event]["event"]
 

--- a/src/gnatss/loaders.py
+++ b/src/gnatss/loaders.py
@@ -203,7 +203,10 @@ def load_dfo(
     for file in file_paths:
         with Path(file).open() as pin_file:
             for line_pin in pin_file:
-                pin_json = json.loads(line_pin)
+                try:
+                    pin_json = json.loads(line_pin)
+                except json.JSONDecodeError:
+                    continue
 
                 # Log event designation
                 event = pin_json["event"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,10 @@ def parsed_configuration() -> Configuration:
 def dfop_configuration() -> Configuration:
     return load_configuration(TEST_DATA_FOLDER / "config_dfop.yaml")
 
+@pytest.fixture(scope="session")
+def bugged_dfop_configuration() -> Configuration:
+    return load_configuration(TEST_DATA_FOLDER / "config_dfop_bugged_files.yaml")
+
 
 @pytest.fixture(scope="session")
 def all_files_dict() -> dict[str, Any]:

--- a/tests/data/config_dfop_bugged_files.yaml
+++ b/tests/data/config_dfop_bugged_files.yaml
@@ -1,0 +1,66 @@
+site_id: NCL1
+campaign: Cascadia
+time_origin: 2022-09-28 00:00:00
+array_center:
+  lat: 45.3023
+  lon: -124.9656
+transponders:
+  - lat: 45.302064471
+    lon: -124.978181346
+    height: -1176.5866
+    internal_delay: 0.200000
+    sv_mean: 1481.551
+  - lat: 45.295207747
+    lon: -124.958752845
+    height: -1146.5881
+    internal_delay: 0.320000
+    sv_mean: 1481.521
+  - lat: 45.309643593
+    lon: -124.959348875
+    height: -1133.7305
+    internal_delay: 0.440000
+    sv_mean: 1481.509
+travel_times_variance: 1e-10
+travel_times_correction: 0.0
+transducer_delay_time: 0.0
+
+# Posfilter configuration
+posfilter:
+  export:
+    full: false
+  atd_offsets:
+    forward: 0.0053
+    rightward: 0
+    downward: 0.92813
+  input_files:
+    novatel:
+      path: ./tests/data/2022/NCL1/NOV/NCL1_INSPVAA.dat
+    novatel_std:
+      path: ./tests/data/2022/NCL1/NOV/NCL1_INSSTDEVA.dat
+    gps_positions:
+      path: ./tests/data/2022/NCL1/**/GPS_PPP/GPS_POS_FREED
+    travel_times:
+      path: ./tests/data/**/DFOP_test_files/*DFOP00.raw
+      format: DFOP
+
+# Solver configuration
+solver:
+  reference_ellipsoid:
+    semi_major_axis: 6378137.000
+    reverse_flattening: 298.257222101
+  gps_sigma_limit: 0.05
+  std_dev: true
+  geoid_undulation: -26.59
+  bisection_tolerance: 1e-10
+  harmonic_mean_start_depth: -4.0
+  input_files:
+    sound_speed:
+      path: ./tests/data/2022/NCL1/ctd/CTD_NCL1_Ch_Mi
+    # deletions: # Path to deletns.dat deletions file used by Chadwell code as well
+    #   path: ../tests/data/2022/NCL1/deletns.dat
+    # gps_solution:
+    #   path: ./test-output/gps_solution.csv
+
+# Output configuration
+output:
+  path: ./test-output/

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -141,6 +141,30 @@ def test_load_dfo(dfop_configuration,time_round):
     )
 
 
+@pytest.mark.parametrize(
+    "time_round",
+    [3],
+)
+def test_load_bugged_dfo(bugged_dfop_configuration,time_round):
+    dfop_files_dict = gather_files_all_procs(bugged_dfop_configuration)
+    travel_time_data = load_dfo(bugged_dfop_configuration,dfop_files_dict["travel_times"],time_round)
+
+    expected_columns = [
+        TIME_J2000,
+        DATA_SPEC.transponder_id,
+        DATA_SPEC.travel_time,
+        DATA_SPEC.tx_time,
+    ]
+
+    assert isinstance(travel_time_data, DataFrame)
+    assert set(expected_columns) == set(travel_time_data.columns.values.tolist())
+    assert is_string_dtype(travel_time_data[DATA_SPEC.transponder_id])
+    assert is_float_dtype(travel_time_data[TIME_J2000])
+    assert all(
+        is_float_dtype(travel_time_data[column]) for column in expected_columns[2:]
+    )
+
+
 def test_load_posfilter_bad_format(configuration):
     bad_config = configuration
     bad_config.posfilter.input_files.gps_positions.format = 'bad_format'


### PR DESCRIPTION
This PR fixes bugs related to rare records in DFOP raw files and targz files that are corrupted and cause gnatss to crash upon loading. Upon finding a corrupted record, it should be skipped when loading the file.

The records/errors checked for are:

  -"ERR3" strings in "GNSS" records of the DFOP/targz JSON structure
  - EOFError in targz binary file
  - JSONDecodeError in DFOP/targz JSON structure